### PR TITLE
Invoke r.OnDataChannel callback for ion-sfu datachannel too

### DIFF
--- a/rtc.go
+++ b/rtc.go
@@ -225,7 +225,6 @@ func (r *RTC) Join(sid, uid string, config ...*JoinConfig) error {
 					r.apiQueue = []Call{}
 				}
 			})
-			return
 		}
 		log.Debugf("%v got dc %v", r.uid, dc.Label())
 		if r.OnDataChannel != nil {


### PR DESCRIPTION
Ultravox expects an initial mute/unmute state msg from clients via
this datachannel with label ion-sfu. And clients can send this msg
by registering r.OnDataChannel